### PR TITLE
Fix link to image broken by previous pull request

### DIFF
--- a/content/alpha_edition/io_playability.md
+++ b/content/alpha_edition/io_playability.md
@@ -2,7 +2,7 @@
 
 ## Pinout and Hardware Diagram
 ### Front
-<center>![Pinout Top](/assets/images/alpha delta top pinout 20200811.png)</center>  
+<center>![Pinout Top](/assets/images/alphadelta top pinout 20200811.png)</center>  
 
 ### Back
 <center>![Pinout Bot](/assets/images/alphadelta bot pinout 20200811.png)</center>


### PR DESCRIPTION
Link to image "alphadelta top pinout 20200811.png" was broken in pull request:
https://github.com/LattePandaTeam/Docs/pull/65

This fixes the link back.