### PR TITLE
Update Operating_Systems.md—Add `pfSense` for the Compatible System List

### DIFF
--- a/content/sigma_edition/Operating_Systems.md
+++ b/content/sigma_edition/Operating_Systems.md
@@ -20,6 +20,7 @@ We've tested the basic functions of various operating systems on LattePanda Sigm
 | Android x86 | 9.0-r2 | 🔴 |      |
 | ChromeOS Flex | 15117.112.0 | 🔴 | |
 | OPNsense | 23.1   | 🟢    |      |
+| pfSense | 2.7.0-RELEASE | 🟢    |      |
 
 \> [!NOTE] 
 


### PR DESCRIPTION
It is worth noting that LattePanda Sigma works with pfSense 2.7.0 without any additional drivers (thanks to using Intel i225-V). No issues found on my device more than 105 days without reboot.

<img width="582" alt="image" src="https://github.com/LattePandaTeam/Docs/assets/18564028/0778bca3-0a4e-449e-bc0a-b49b0530efb4">

